### PR TITLE
228 video tab update on client change (#279)

### DIFF
--- a/OVP/D3D7Client/VideoTab.cpp
+++ b/OVP/D3D7Client/VideoTab.cpp
@@ -138,6 +138,14 @@ void VideoTab::Initialise (D3D7Enum_DeviceInfo *dev)
 	DWORD i, ndev, idx;
 	D3D7Enum_GetDevices (&devlist, &ndev);
 
+	// Make sure all controls are reset to default configurations in case another client
+	// modified them
+	SetWindowText(GetDlgItem(hTab, IDC_VID_ENUM), "Always enumerate devices");
+	EnableWindow(GetDlgItem(hTab, IDC_VID_ENUM), true);
+	SetWindowText(GetDlgItem(hTab, IDC_VID_STENCIL), "Try stencil buffer");
+	EnableWindow(GetDlgItem(hTab, IDC_VID_STENCIL), true);
+	SetWindowText(GetDlgItem(hTab, IDC_VID_PAGEFLIP), "Hardware pageflip");
+
 	SendDlgItemMessage (hTab, IDC_VID_DEVICE, CB_RESETCONTENT, 0, 0);
 	for (i = 0; i < ndev; i++) {
 		SendMessage (GetDlgItem (hTab, IDC_VID_DEVICE), CB_ADDSTRING, 0,
@@ -227,6 +235,10 @@ void VideoTab::SelectDevice (D3D7Enum_DeviceInfo *dev)
 void VideoTab::SelectDispmode (D3D7Enum_DeviceInfo *dev, BOOL bWindow)
 {
 	DWORD i;
+	if ((SendDlgItemMessage(hTab, IDC_VID_WINDOW, BM_GETCHECK, 0, 0) == BST_CHECKED) != (bWindow != 0)) {
+		SendDlgItemMessage(hTab, IDC_VID_WINDOW, BM_SETCHECK, bWindow ? BST_CHECKED : BST_UNCHECKED, 0);
+		SendDlgItemMessage(hTab, IDC_VID_FULL, BM_SETCHECK, bWindow ? BST_UNCHECKED : BST_CHECKED, 0);
+	}
 	for (i = 0; i < 6; i++)
 		EnableWindow (GetDlgItem (hTab, IDC_VID_STATIC5+i), !bWindow);
 	for (i = 0; i < 9; i++)

--- a/Src/Orbiter/TabVideo.cpp
+++ b/Src/Orbiter/TabVideo.cpp
@@ -101,11 +101,12 @@ void orbiter::DefVideoTab::OnGraphicsClientLoaded(oapi::GraphicsClient* gc, cons
 	char fname[256];
 	_splitpath(moduleName, NULL, NULL, fname, NULL);
 
-	int oldIdx = SendDlgItemMessage(hTab, IDC_VID_COMBO_MODULE, CB_GETCURSEL, 0, 0);
 	int newIdx = SendDlgItemMessage(hTab, IDC_VID_COMBO_MODULE, CB_FINDSTRING, -1, (LPARAM)fname);
-	if (newIdx != oldIdx) {
+	if (newIdx != idxClient) {
 		SendDlgItemMessage(hTab, IDC_VID_COMBO_MODULE, CB_SETCURSEL, newIdx, 0);
-		SelectClientIndex(newIdx);
+		ShowInterface(hTab, newIdx > 0);
+		pCfg->AddModule(fname); // make the graphics client "active" so it is loaded on next app start
+		idxClient = newIdx;
 	}
 
 	HMODULE hMod = LoadLibraryEx(moduleName, 0, LOAD_LIBRARY_AS_DATAFILE);
@@ -239,22 +240,22 @@ void orbiter::DefVideoTab::ScanDir(HWND hTab, const PSTR dir)
 
 void orbiter::DefVideoTab::SelectClientIndex(UINT idx)
 {
+	ShowInterface(hTab, idx > 0);
+
 	char name[256];
-	if (idxClient) {
+	if (idxClient) { // unload the current client
 		SendDlgItemMessage(hTab, IDC_VID_COMBO_MODULE, CB_GETLBTEXT, idxClient, (LPARAM)name);
 		pCfg->DelModule(name);
 		pLp->App()->UnloadModule(name);
+		pCfg->CfgDevPrm.Device_idx = -1;
 	}
-	if (idxClient = idx) {
+	if (idx) { // load the new client
 		const char* path = "Modules\\Plugin";
-		SendDlgItemMessage(hTab, IDC_VID_COMBO_MODULE, CB_GETLBTEXT, idxClient, (LPARAM)name);
-		pCfg->AddModule(name);
+		SendDlgItemMessage(hTab, IDC_VID_COMBO_MODULE, CB_GETLBTEXT, idx, (LPARAM)name);
 		pLp->App()->LoadModule(path, name);
 	}
 	else
 		SetInfoString(strInfo_Default);
-
-	ShowInterface(hTab, idx > 0);
 }
 
 void orbiter::DefVideoTab::SetInfoString(PSTR str)


### PR DESCRIPTION
* #228: fixed bug that loaded graphics client twice on startup and prevented it from properly unloading on switching to a different client.

* #228: bug fix: previously selected graphics client was not retained at next Orbiter run.

* #228: restore more video tab item captions for D3D7Client.

* #228: rearranged video tab initialisation.

* #228: D3D7Client: fix incorrect fullscreen selection on startup.

* #228: make sure graphics devices are rescanned on client switch.